### PR TITLE
[PERF] Interrupt solver at known utility upper bound.

### DIFF
--- a/schedulers/tetrisched/include/tetrisched/GurobiSolver.hpp
+++ b/schedulers/tetrisched/include/tetrisched/GurobiSolver.hpp
@@ -8,36 +8,13 @@ namespace tetrisched {
 
 class GurobiSolver : public Solver {
  private:
-  /// The environment variable for this instance of Gurobi.
-  std::unique_ptr<GRBEnv> gurobiEnv;
-  /// The model being used by this solver.
-  std::unique_ptr<GRBModel> gurobiModel;
-  /// The SolverModel instance associated with this GurobiSolver.
-  SolverModelPtr solverModel;
-  /// The name of the log file for the Gurobi solving.
-  std::string logFileName;
-
-  /// Set the defaults for parameters on the model.
-  void setParameters(GRBModel& gurobiModel);
-
-  /// Translate the variable to a Gurobi variable.
-  GRBVar translateVariable(GRBModel& gurobiModel,
-                           const VariablePtr& variable) const;
-
-  /// Translate the Constraint into a Gurobi expression.
-  GRBConstr translateConstraint(GRBModel& gurobiModel,
-                                const ConstraintPtr& constraint) const;
-
-  /// Translate the ObjectiveFunction into a Gurobi expression.
-  GRBLinExpr translateObjectiveFunction(
-      GRBModel& gurobiModel,
-      const ObjectiveFunctionPtr& objectiveFunction) const;
-
   /// A structure representing the parameters that the interrupt callback
   /// can use to determine when to interrupt the computation.
   struct GurobiInterruptParams {
     /// The time limit for the optimization (in milliseconds).
-    Time timeLimitMs;
+    std::optional<Time> timeLimitMs;
+    /// The upper bound of the utility (if available).
+    std::optional<TETRISCHED_ILP_TYPE> utilityUpperBound;
   };
 
   /// Callback class for Gurobi to use to interrupt the optimization.
@@ -57,6 +34,33 @@ class GurobiSolver : public Solver {
     /// optimization.
     void callback();
   };
+
+  /// The environment variable for this instance of Gurobi.
+  std::unique_ptr<GRBEnv> gurobiEnv;
+  /// The model being used by this solver.
+  std::unique_ptr<GRBModel> gurobiModel;
+  /// The SolverModel instance associated with this GurobiSolver.
+  SolverModelPtr solverModel;
+  /// The name of the log file for the Gurobi solving.
+  std::string logFileName;
+  /// The interrupt parameters for the current iteration of the optimization.
+  GurobiInterruptParams interruptParams;
+
+  /// Set the defaults for parameters on the model.
+  void setParameters(GRBModel& gurobiModel);
+
+  /// Translate the variable to a Gurobi variable.
+  GRBVar translateVariable(GRBModel& gurobiModel,
+                           const VariablePtr& variable) const;
+
+  /// Translate the Constraint into a Gurobi expression.
+  GRBConstr translateConstraint(GRBModel& gurobiModel,
+                                const ConstraintPtr& constraint) const;
+
+  /// Translate the ObjectiveFunction into a Gurobi expression.
+  GRBLinExpr translateObjectiveFunction(
+      GRBModel& gurobiModel,
+      const ObjectiveFunctionPtr& objectiveFunction) const;
 
  public:
   /// Create a new GurobiSolver.

--- a/schedulers/tetrisched/include/tetrisched/Solver.hpp
+++ b/schedulers/tetrisched/include/tetrisched/Solver.hpp
@@ -33,7 +33,11 @@ enum SolutionType {
   /// The Solver returned an unbounded solution.
   UNBOUNDED = 3,
   /// The Solver returned an unknown solution.
-  UNKNOWN = 4
+  UNKNOWN = 4,
+  /// The Solver returned no solution.
+  /// This usually occurs when the Solver is interrupted before it has
+  /// found a solution.
+  NO_SOLUTION = 5,
 };
 
 /// The SolverSolution structure represents the information that we
@@ -66,6 +70,8 @@ struct SolverSolution {
         return "UNBOUNDED";
       case SolutionType::UNKNOWN:
         return "UNKNOWN";
+      case SolutionType::NO_SOLUTION:
+        return "NO_SOLUTION";
       default:
         return "NOTIMPLEMENTED";
     }

--- a/schedulers/tetrisched/include/tetrisched/SolverModel.hpp
+++ b/schedulers/tetrisched/include/tetrisched/SolverModel.hpp
@@ -325,6 +325,8 @@ class ObjectiveFunctionT {
   tbb::concurrent_vector<std::pair<T, std::shared_ptr<VariableT<T>>>> terms;
   /// The type of the objective function.
   ObjectiveType objectiveType;
+  /// The upper bound of the utility function, if provided.
+  std::optional<T> upperBound;
 
  public:
   ObjectiveFunctionT(const ObjectiveFunctionT& other) = default;
@@ -335,6 +337,9 @@ class ObjectiveFunctionT {
   /// Adds a term to the left-hand side constraint.
   void addTerm(T coefficient, std::shared_ptr<VariableT<T>> variable);
   void addTerm(T constant);
+
+  /// Sets the uppper bound of the utility value.
+  void setUpperBound(T upperBound);
 
   // The objective is left hand side of the constraint
   std::shared_ptr<ConstraintT<T>> toConstraint(std::string constraintName,

--- a/schedulers/tetrisched/python/Backends.cpp
+++ b/schedulers/tetrisched/python/Backends.cpp
@@ -11,7 +11,8 @@ void defineSolverSolution(py::module_& tetrisched_m) {
       .value("OPTIMAL", tetrisched::SolutionType::OPTIMAL)
       .value("INFEASIBLE", tetrisched::SolutionType::INFEASIBLE)
       .value("UNBOUNDED", tetrisched::SolutionType::UNBOUNDED)
-      .value("UNKNOWN", tetrisched::SolutionType::UNKNOWN);
+      .value("UNKNOWN", tetrisched::SolutionType::UNKNOWN)
+      .value("NO_SOLUTION", tetrisched::SolutionType::NO_SOLUTION);
 
   // Define the backend type enum.
   py::enum_<tetrisched::SolverBackendType>(tetrisched_m, "SolverBackendType")

--- a/schedulers/tetrisched/src/Expression.cpp
+++ b/schedulers/tetrisched/src/Expression.cpp
@@ -1542,6 +1542,7 @@ ParseResultPtr ObjectiveExpression::parse(
   parsedResult->endTime = std::numeric_limits<Time>::max();
   if (useUtilityBound) {
     parsedResult->utilityBound = utilityBound;
+    utility->setUpperBound(utilityBound);
   }
 
   // Add the utility to the SolverModel.

--- a/schedulers/tetrisched/src/GurobiSolver.cpp
+++ b/schedulers/tetrisched/src/GurobiSolver.cpp
@@ -4,6 +4,8 @@
 #include <cmath>
 #include <thread>
 
+#define TETRISCHED_SOLUTION_UPPER_BOUND_DELTA 0.1
+
 namespace tetrisched {
 
 /**
@@ -16,13 +18,19 @@ GurobiSolver::GurobiInterruptOptimizationCallback::
 void GurobiSolver::GurobiInterruptOptimizationCallback::callback() {
   try {
     auto currentTime = std::chrono::steady_clock::now();
-    if (where == GRB_CB_POLLING) {
+    if (where == GRB_CB_POLLING && params.timeLimitMs.has_value()) {
       auto elapsedTimeMs =
           std::chrono::duration_cast<std::chrono::milliseconds>(currentTime -
                                                                 startTime)
               .count();
 
-      if (elapsedTimeMs > params.timeLimitMs) {
+      if (elapsedTimeMs > params.timeLimitMs.value()) {
+        abort();
+      }
+    } else if (where == GRB_CB_MIPSOL && params.utilityUpperBound.has_value()) {
+      if (getDoubleInfo(GRB_CB_MIPSOL_OBJ) >=
+          params.utilityUpperBound.value() -
+              TETRISCHED_SOLUTION_UPPER_BOUND_DELTA) {
         abort();
       }
     }
@@ -42,9 +50,7 @@ void GurobiSolver::GurobiInterruptOptimizationCallback::callback() {
 GurobiSolver::GurobiSolver()
     : gurobiEnv(new GRBEnv()),
       gurobiModel(new GRBModel(*gurobiEnv)),
-      logFileName("") {
-  setParameters(*gurobiModel);
-}
+      logFileName("") {}
 
 SolverModelPtr GurobiSolver::getModel() {
   if (!solverModel) {
@@ -261,6 +267,12 @@ void GurobiSolver::translateModel() {
           "Invalid objective type: " +
           std::to_string(solverModel->objectiveFunction->objectiveType));
   }
+
+  // Construct the Interrupt parameters.
+  if (solverModel->objectiveFunction->upperBound.has_value()) {
+    interruptParams.utilityUpperBound =
+        solverModel->objectiveFunction->upperBound.value();
+  }
 }
 
 void GurobiSolver::exportModel(const std::string& fileName) {
@@ -274,6 +286,10 @@ void GurobiSolver::setLogFile(const std::string& fileName) {
 SolverSolutionPtr GurobiSolver::solveModel() {
   // Create the result object.
   SolverSolutionPtr solverSolution = std::make_shared<SolverSolution>();
+
+  // Construct the Interrupt callback, and register it with the model.
+  GurobiInterruptOptimizationCallback interruptCallback(interruptParams);
+  gurobiModel->setCallback(&interruptCallback);
 
   // Solve the model.
   auto solverStartTime = std::chrono::high_resolution_clock::now();
@@ -297,6 +313,16 @@ SolverSolutionPtr GurobiSolver::solveModel() {
     case GRB_INFEASIBLE:
       solverSolution->solutionType = SolutionType::INFEASIBLE;
       return solverSolution;
+    case GRB_INTERRUPTED: {
+      auto solutionCount = gurobiModel->get(GRB_IntAttr_SolCount);
+      if (solutionCount > 0) {
+        solverSolution->solutionType = SolutionType::FEASIBLE;
+        break;
+      } else {
+        solverSolution->solutionType = SolutionType::NO_SOLUTION;
+        return solverSolution;
+      }
+    }
     case GRB_INF_OR_UNBD:
     case GRB_UNBOUNDED:
       solverSolution->solutionType = SolutionType::UNBOUNDED;

--- a/schedulers/tetrisched/src/SolverModel.cpp
+++ b/schedulers/tetrisched/src/SolverModel.cpp
@@ -285,6 +285,11 @@ void ObjectiveFunctionT<T>::addTerm(T constant) {
 }
 
 template <typename T>
+void ObjectiveFunctionT<T>::setUpperBound(T upperBound) {
+  this->upperBound = upperBound;
+}
+
+template <typename T>
 std::shared_ptr<ConstraintT<T>> ObjectiveFunctionT<T>::toConstraint(
     std::string constraintName, ConstraintType constraintType,
     T rightHandSide) const {


### PR DESCRIPTION
**Problem Description**
The warm starts and Gurobi's own heuristics are usually able to find a good heuristic solution to our problem. However, to know that the solution is good, the solver must solve the LP relaxation. This puts us through the expensive presolve process unnecessarily when the heuristics / warm starts have already figured out a known optimal solution.

However, our declarative language can provide us with an upper bound on the objective during parsing. This PR implements an interrupt callback in Gurobi that watches for any solution within `TETRISCHED_SOLUTION_UPPER_BOUND_DELTA` and interrupts the solver as soon as one is found. This skips over cases where we find the solution early and either: a) still have to solve the LP relaxation, or b) have to converge to a good objective bound.

**Performance Benefits**:
Tested this on a random sample from Alibaba trace and the runtimes are plotted below:

![post_opt](https://github.com/erdos-project/erdos-scheduling-simulator/assets/4013287/51e7acea-5ca6-432d-b7e6-1df852755c74)

Note that this change does not have any effect on the goodput of the scheduler since it does not invalidate any good solutions.