### PR TITLE
[WIP-GRAPHENE] Implement Graphene Scheduler

### DIFF
--- a/configs/simple_graphene_workload.conf
+++ b/configs/simple_graphene_workload.conf
@@ -1,0 +1,16 @@
+# Output configs
+--log=./simple_graphene_workload.log
+--log_level=debug
+--csv=./simple_graphene_workload.csv
+
+# Task configs
+--runtime_variance=0
+
+# Scheduler configs
+--scheduler=Graphene
+--scheduler_runtime=0
+
+# Execution mode configs
+--execution_mode=json
+--workload_profile_path=./profiles/workload/simple_graphene_workload.yaml
+--worker_profile_path=./profiles/workers/simple_graphene_workers.yaml

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ from schedulers import (
     ClockworkScheduler,
     EDFScheduler,
     FIFOScheduler,
+    GrapheneScheduler,
     ILPScheduler,
     LSFScheduler,
     TetriSchedCPLEXScheduler,
@@ -289,6 +290,7 @@ flags.DEFINE_enum(
         "Clockwork",
         "TetriSched",
         "GraphenePrime",
+        "Graphene",
     ],
     "The scheduler to use for this execution.",
 )
@@ -817,6 +819,20 @@ def main(args):
             # Graphene aims to minimize the makespan of the schedule, so we force the
             # goal of the Scheduler to be the minimum placement delay.
             goal="min_placement_delay",
+            time_discretization=EventTime(
+                FLAGS.scheduler_time_discretization, EventTime.Unit.US
+            ),
+            plan_ahead=EventTime(FLAGS.scheduler_plan_ahead, EventTime.Unit.US),
+            log_to_file=FLAGS.scheduler_log_to_file,
+            _flags=FLAGS,
+        )
+    elif FLAGS.scheduler == "Graphene":
+        scheduler = GrapheneScheduler(
+            preemptive=FLAGS.preemption,
+            runtime=EventTime(FLAGS.scheduler_runtime, EventTime.Unit.US),
+            lookahead=EventTime(FLAGS.scheduler_lookahead, EventTime.Unit.US),
+            retract_schedules=FLAGS.retract_schedules,
+            goal=FLAGS.ilp_goal,
             time_discretization=EventTime(
                 FLAGS.scheduler_time_discretization, EventTime.Unit.US
             ),

--- a/profiles/workers/simple_graphene_workers.yaml
+++ b/profiles/workers/simple_graphene_workers.yaml
@@ -1,0 +1,6 @@
+- name: WorkerPool_1
+  workers:
+      - name: Worker_1_1
+        resources:
+            - name: Slot
+              quantity: 3

--- a/profiles/workload/simple_graphene_workload.yaml
+++ b/profiles/workload/simple_graphene_workload.yaml
@@ -1,0 +1,73 @@
+# Implementation of the example workload specified in the Graphene paper.
+# This workload is being used to test the Offline and Online stages of the
+# ILP-based reimplementation of the Graphene algorithm.
+graphs:
+  - name: GrapheneMotivation
+    graph:
+      - name: "Task0"
+        work_profile: "Task0Profile"
+        children: ["Task6"]
+      - name: "Task1"
+        work_profile: "Task1Profile"
+        children: ["Task2"]
+      - name: "Task2"
+        work_profile: "Task2Profile"
+        children: ["Task6"]
+      - name: "Task3"
+        work_profile: "Task3Profile"
+        children: ["Task4"]
+      - name: "Task4"
+        work_profile: "Task4Profile"
+        children: ["Task5"]
+      - name: "Task5"
+        work_profile: "Task5Profile"
+        children: ["Task6"]
+      - name: "Task6"
+        work_profile: "Task6Profile"
+    release_policy: fixed
+    period: 0 # In us for now.
+    invocations: 1
+    deadline_variance: [2000, 2000]
+profiles:
+  - name: Task0Profile
+    execution_strategies:
+      - batch_size: 1
+        runtime: 100
+        resource_requirements:
+          Slot:any: 1
+  - name: Task1Profile
+    execution_strategies:
+      - batch_size: 1
+        runtime: 20
+        resource_requirements:
+          Slot:any: 3
+  - name: Task2Profile
+    execution_strategies:
+      - batch_size: 1
+        runtime: 100
+        resource_requirements:
+          Slot:any: 1
+  - name: Task3Profile
+    execution_strategies:
+      - batch_size: 1
+        runtime: 20
+        resource_requirements:
+          Slot:any: 3
+  - name: Task4Profile
+    execution_strategies:
+      - batch_size: 1
+        runtime: 20
+        resource_requirements:
+          Slot:any: 3
+  - name: Task5Profile
+    execution_strategies:
+      - batch_size: 1
+        runtime: 100
+        resource_requirements:
+          Slot:any: 1
+  - name: Task6Profile
+    execution_strategies:
+      - batch_size: 1
+        runtime: 20
+        resource_requirements:
+          Slot:any: 1

--- a/schedulers/__init__.py
+++ b/schedulers/__init__.py
@@ -15,4 +15,9 @@ try:
     from .tetrisched_scheduler import TetriSchedScheduler
 except ImportError:
     pass
+
+try:
+    from .graphene_scheduler import GrapheneScheduler
+except ImportError:
+    pass
 from .z3_scheduler import Z3Scheduler

--- a/schedulers/__init__.py
+++ b/schedulers/__init__.py
@@ -12,12 +12,9 @@ from .tetrisched_cplex_scheduler import TetriSchedCPLEXScheduler
 from .tetrisched_gurobi_scheduler import TetriSchedGurobiScheduler
 
 try:
+    from .graphene_scheduler import GrapheneScheduler
     from .tetrisched_scheduler import TetriSchedScheduler
 except ImportError:
     pass
 
-try:
-    from .graphene_scheduler import GrapheneScheduler
-except ImportError:
-    pass
 from .z3_scheduler import Z3Scheduler

--- a/schedulers/base_scheduler.py
+++ b/schedulers/base_scheduler.py
@@ -179,6 +179,25 @@ class BaseScheduler(object):
             placements=placements,
         )
 
+    def notify_workload_updated(
+        self,
+        sim_time: EventTime,
+        workload: Workload,
+        worker_pools: "WorkerPools",  # noqa: F821
+    ) -> None:
+        """Notifies the Scheduler that the Workload has been updated.
+
+        The Simulator invokes this method to notify the Scheduler that it can do
+        any necessary bookkeeping or updates to its internal state.
+
+        Args:
+            sim_time (`EventTime`): The time at which the workload was updated.
+            workload (`Workload`): The `Workload` that was updated.
+            worker_pools (`WorkerPools`): The set of worker pools available to the
+                Scheduler at the update of the Workload.
+        """
+        pass
+
     def schedule(
         self,
         sim_time: EventTime,

--- a/schedulers/graphene_scheduler.py
+++ b/schedulers/graphene_scheduler.py
@@ -1,17 +1,15 @@
-try:
-    from .tetrisched_scheduler import TetriSchedScheduler
-except ImportError:
-    raise ImportError(
-        "TetriSchedScheduler not found. " "Please install the TetriSched package."
-    )
-
+import os
 from typing import Optional
 
 import absl  # noqa: F401
+import numpy as np
+import tetrisched_py as tetrisched
 
 from utils import EventTime
 from workers import WorkerPools
 from workload import Placements, Workload
+
+from .tetrisched_scheduler import Partitions, TetriSchedScheduler
 
 
 class GrapheneScheduler(TetriSchedScheduler):
@@ -63,13 +61,34 @@ class GrapheneScheduler(TetriSchedScheduler):
             _flags=_flags,
         )
 
+        # The Graphene scheduler is a STRL-based scheduler, and it requires the
+        # TetriSched framework to solve the STRL formulation.
+        self._min_makespan_scheduler = tetrisched.Scheduler(
+            self._time_discretization.time,
+            tetrisched.backends.SolverBackendType.GUROBI,
+            self._log_dir,
+        )
+        self._min_makespan_scheduler_configuration = tetrisched.SchedulerConfig()
+        self._min_makespan_scheduler_configuration.optimize = (
+            self._enable_optimization_passes
+        )
+
         # Keep a hash set of the TaskGraph names that have been transformed by the
         # scheduler already.
         self._transformed_taskgraphs = set()
 
+        # Configuration parameters for the Offline phase of the Graphene scheduler.
+        # The plan-ahead multiplier is used to determine the plan-ahead window for each
+        # of the TaskGraph in the Offline phase. The multiplier is multiplied by the
+        # critical path length of the TaskGraph to determine the plan-ahead window.
+        self._plan_ahead_multiplier = 2
+
     def schedule(
         self, sim_time: EventTime, workload: Workload, worker_pools: WorkerPools
     ) -> Placements:
+        # Create a Partitions object from the WorkerPools that are available.
+        partitions = Partitions(worker_pools=worker_pools)
+
         # Find the task graphs that have been added to the Workload but not yet
         # transformed by the Graphene scheduler.
         for task_graph_name, task_graph in workload.task_graphs.items():
@@ -85,6 +104,83 @@ class GrapheneScheduler(TetriSchedScheduler):
                 sim_time.time,
                 task_graph_name,
             )
+
+            # Create the rewards for the Placement times that allow STRL to construct
+            # a minimum makespan schedule for this graph.
+            critical_path_runtime = task_graph.critical_path_runtime
+            dilated_critical_path_runtime = EventTime(
+                int(critical_path_runtime.time * self._plan_ahead_multiplier),
+                critical_path_runtime.unit,
+            )
+            placement_times = self._get_time_discretizations_until(
+                current_time=sim_time,
+                end_time=sim_time + dilated_critical_path_runtime,
+            )
+            placement_times_and_rewards = list(
+                zip(
+                    placement_times,
+                    np.interp(
+                        list(map(lambda x: x.time, placement_times)),
+                        (
+                            min(placement_times).time,
+                            max(placement_times).time,
+                        ),
+                        (2, 1),
+                    ),
+                )
+            )
+
+            # Construct the STRL formulation for the minimum makespan scheduling of the
+            # particular TaskGraph. This corresponds to the first (offline) phase of
+            # the Graphene scheduling algorithm.
+            objective_strl = tetrisched.strl.ObjectiveExpression(
+                f"{task_graph_name}_min_makespan"
+            )
+            task_graph_strl = self.construct_task_graph_strl(
+                current_time=sim_time,
+                task_graph=task_graph,
+                partitions=partitions,
+                placement_times_and_rewards=placement_times_and_rewards,
+            )
+            if task_graph_strl is None:
+                raise ValueError(f"Failed to construct the STRL for {task_graph_name}.")
+            self._logger.debug(
+                "[%s] Successfully constructed the minimum makespan "
+                "STRL for TaskGraph %s.",
+                sim_time.time,
+                task_graph_name,
+            )
+            objective_strl.addChild(task_graph_strl)
+
+            # Register the STRL expression with the scheduler and solve it.
+            try:
+                self._min_makespan_scheduler.registerSTRL(
+                    objective_strl,
+                    partitions.partitions,
+                    sim_time.time,
+                    self._min_makespan_scheduler_configuration,
+                )
+                self._min_makespan_scheduler.schedule(sim_time.time)
+            except RuntimeError as e:
+                strl_file_name = f"{task_graph_name}_error.dot"
+                solver_model_file_name = f"{task_graph_name}_error.lp"
+                self._logger.error(
+                    "[%s] Received error with description: %s while invoking the "
+                    "STRL-based minimum makespan scheduler for TaskGraph %s. Dumping "
+                    "the model to %s and STRL expression to %s.",
+                    sim_time.time,
+                    e,
+                    task_graph_name,
+                    solver_model_file_name,
+                    strl_file_name,
+                )
+                objective_strl.exportToDot(os.path.join(self._log_dir, strl_file_name))
+                self._min_makespan_scheduler.exportLastSolverModel(
+                    os.path.join(self._log_dir, solver_model_file_name)
+                )
+
+                # TODO (Sukrit): Retrieve the order of placements from the solver, and
+                # construct the new TaskGraph with the placements.
 
         # All the TaskGraphs have been transformed, call the TetriSched scheduler and
         # return the Placements.

--- a/schedulers/graphene_scheduler.py
+++ b/schedulers/graphene_scheduler.py
@@ -5,6 +5,87 @@ except ImportError:
         "TetriSchedScheduler not found. " "Please install the TetriSched package."
     )
 
+from typing import Optional
+
+import absl  # noqa: F401
+
+from utils import EventTime
+from workers import WorkerPools
+from workload import Placements, Workload
+
 
 class GrapheneScheduler(TetriSchedScheduler):
-    pass
+    """Implements a STRL-based formulation for the Graphene scheduler.
+
+    The Graphene paper proposes a min-JCT scheduler that works in the following two
+    stages:
+        1. An Offline stage that constructs an ordering for the Tasks in a DAG assuming
+            a completely empty resource-time space, and modifies the DAG structure to
+            correspond to the newly created execution ordering.
+        2. An Online stage that schedules the tasks of the modified DAG as they are
+            released using a packing-aware scheduler.
+
+    To achieve similar goals, we provide a faithful reimplementation of the Graphene
+    scheduler using the TetriSched framework:
+        1. For the offline stage, we construct a STRL formulation that minimizes the
+            makespan of the DAG, and use the TetriSched framework to solve it.
+        2. For the online stage, we use the TetriSched framework to schedule the tasks
+            of the modified DAG as they are released and maximize packing within a
+            given plan-ahead window.
+    """
+
+    def __init__(
+        self,
+        preemptive: bool = False,
+        runtime: EventTime = EventTime.invalid(),
+        lookahead: EventTime = EventTime.zero(),
+        retract_schedules: bool = False,
+        goal: str = "max_goodput",
+        time_discretization: EventTime = EventTime(1, EventTime.Unit.US),
+        plan_ahead: EventTime = EventTime.invalid(),
+        log_to_file: bool = False,
+        _flags: Optional["absl.flags"] = None,
+    ):
+        super(GrapheneScheduler, self).__init__(
+            preemptive=preemptive,
+            runtime=runtime,
+            lookahead=lookahead,
+            # The Graphene scheduler has no notion of deadlines.
+            enforce_deadlines=False,
+            retract_schedules=retract_schedules,
+            # The Graphene scheduler will modify TaskGraphs when they arrive, but
+            # otherwise, the Workload should assume task-only scheduling.
+            release_taskgraphs=False,
+            goal=goal,
+            time_discretization=time_discretization,
+            plan_ahead=plan_ahead,
+            log_to_file=log_to_file,
+            _flags=_flags,
+        )
+
+        # Keep a hash set of the TaskGraph names that have been transformed by the
+        # scheduler already.
+        self._transformed_taskgraphs = set()
+
+    def schedule(
+        self, sim_time: EventTime, workload: Workload, worker_pools: WorkerPools
+    ) -> Placements:
+        # Find the task graphs that have been added to the Workload but not yet
+        # transformed by the Graphene scheduler.
+        for task_graph_name, task_graph in workload.task_graphs.items():
+            if task_graph_name in self._transformed_taskgraphs:
+                self._logger.debug(
+                    "[%s] TaskGraph %s has already been transformed.",
+                    sim_time.time,
+                    task_graph_name,
+                )
+                continue
+            self._logger.debug(
+                "[%s] Transforming TaskGraph %s.",
+                sim_time.time,
+                task_graph_name,
+            )
+
+        # All the TaskGraphs have been transformed, call the TetriSched scheduler and
+        # return the Placements.
+        return super(GrapheneScheduler, self).schedule(sim_time, workload, worker_pools)

--- a/schedulers/graphene_scheduler.py
+++ b/schedulers/graphene_scheduler.py
@@ -276,8 +276,8 @@ class GrapheneScheduler(TetriSchedScheduler):
                             )
                             if previous_task is None:
                                 raise ValueError(
-                                    f"Failed to find the Task {previous_placement.name} "
-                                    f"in TaskGraph {task_graph.name}."
+                                    f"Failed to find the Task {previous_placement.name}"
+                                    f" in TaskGraph {task_graph.name}."
                                 )
                             strategies = previous_task.available_execution_strategies
                             fastest_strategy = strategies.get_fastest_strategy()

--- a/schedulers/graphene_scheduler.py
+++ b/schedulers/graphene_scheduler.py
@@ -1,5 +1,8 @@
 import os
-from typing import Optional
+from collections import defaultdict
+from itertools import groupby
+from operator import attrgetter
+from typing import List, Mapping, Optional, Sequence
 
 import absl  # noqa: F401
 import numpy as np
@@ -7,7 +10,7 @@ import tetrisched_py as tetrisched
 
 from utils import EventTime
 from workers import WorkerPools
-from workload import Placements, Workload
+from workload import Placements, Task, TaskGraph, Workload
 
 from .tetrisched_scheduler import Partitions, TetriSchedScheduler
 
@@ -60,6 +63,7 @@ class GrapheneScheduler(TetriSchedScheduler):
             log_to_file=log_to_file,
             _flags=_flags,
         )
+        self._log_graphs = _flags.log_graphs if _flags else False
 
         # The Graphene scheduler is a STRL-based scheduler, and it requires the
         # TetriSched framework to solve the STRL formulation.
@@ -178,9 +182,145 @@ class GrapheneScheduler(TetriSchedScheduler):
                 self._min_makespan_scheduler.exportLastSolverModel(
                     os.path.join(self._log_dir, solver_model_file_name)
                 )
+                raise e
 
-                # TODO (Sukrit): Retrieve the order of placements from the solver, and
-                # construct the new TaskGraph with the placements.
+            # TODO (Sukrit): Retrieve the order of placements from the solver, and
+            # construct the new TaskGraph with the placements.
+            if not self._min_makespan_scheduler.getLastSolverSolution().isValid():
+                strl_file_name = f"{task_graph_name}_error.dot"
+                solver_model_file_name = f"{task_graph_name}_error.lp"
+                self._logger.error(
+                    "[%s] The minimum makespan scheduler failed to find a solution "
+                    "for the STRL expression of the TaskGraph %s. Dumping the model "
+                    "to %s and the STRL expression to %s.",
+                    sim_time.time,
+                    task_graph_name,
+                    solver_model_file_name,
+                    strl_file_name,
+                )
+                raise ValueError(
+                    f"Failed to find a minimum makespan solution "
+                    f"for the TaskGraph {task_graph_name}."
+                )
+
+            # Retrieve the solution and check if we were able to find a valid solution.
+            task_graph_solution = objective_strl.getSolution()
+            if task_graph_solution is not None and task_graph_solution.utility > 0:
+                self._logger.info(
+                    "[%s] Successfully found a minimum makespan solution for "
+                    "TaskGraph %s and the utility was %s.",
+                    sim_time.time,
+                    task_graph_name,
+                    task_graph_solution.utility,
+                )
+                # Retrieve all the Placements for the Tasks in the TaskGraph and sort
+                # them by their placement time.
+                placements = []
+                for task in task_graph.get_nodes():
+                    task_placement = task_graph_solution.getPlacement(task.unique_name)
+                    if task_placement is None:
+                        self._logger.error(
+                            "[%s] A utility for the TaskGraph %s was found, but "
+                            "the Task %s has no recorded Placement object.",
+                            sim_time.time,
+                            task.task_graph,
+                            task.unique_name,
+                        )
+                        raise ValueError(
+                            f"Failed to find a placement for the Task "
+                            f"{task.unique_name} in the TaskGraph {task.task_graph}."
+                        )
+                    placements.append(task_placement)
+
+                # Sort the placements by their start time and divide them up into stages
+                # by grouped start times. We enforce direct dependencies between all
+                # the tasks in each stage. Within a stage, we introduce dependencies
+                # between tasks that run sequentially.
+                stages = groupby(
+                    sorted(placements, key=attrgetter("startTime")),
+                    key=attrgetter("startTime"),
+                )
+                stage_to_task_map: Mapping[int, List[tetrisched.strl.Placement]] = {}
+                for index, stage in enumerate(stages):
+                    stage_start, placements = stage
+                    stage_to_task_map[index] = list(placements)
+                    self._logger.debug(
+                        "[%s] Constructed stage %s for %s with "
+                        "start time %s and %s elements.",
+                        sim_time.time,
+                        index,
+                        task_graph_name,
+                        stage_start,
+                        len(stage_to_task_map[index]),
+                    )
+
+                # Now that the stages have been constructed, we can construct an
+                # adjacency matrix for the TaskGraph by adding a dependency between
+                # a Task in stage i and all the Tasks in stage i - 1 that finish before.
+                updated_tasks_adjacency_matrix: Mapping[Task, Sequence[Task]] = (
+                    defaultdict(list)
+                )
+                for stage_index, stage in stage_to_task_map.items():
+                    for placement in stage:
+                        task = task_graph.get_task(placement.name, unique=True)
+                        if task is None:
+                            raise ValueError(
+                                f"Failed to find the Task {placement.name} "
+                                f"in TaskGraph {task_graph.name}."
+                            )
+                        for previous_placement in stage_to_task_map.get(
+                            stage_index - 1, []
+                        ):
+                            previous_task = task_graph.get_task(
+                                previous_placement.name, unique=True
+                            )
+                            if previous_task is None:
+                                raise ValueError(
+                                    f"Failed to find the Task {previous_placement.name} "
+                                    f"in TaskGraph {task_graph.name}."
+                                )
+                            strategies = previous_task.available_execution_strategies
+                            fastest_strategy = strategies.get_fastest_strategy()
+                            task_runtime = fastest_strategy.runtime.time
+                            if (
+                                previous_placement.startTime + task_runtime
+                                <= placement.startTime
+                            ):
+                                # This Task finishes before the current Task starts in
+                                # the offline order, so we add a dependency between
+                                # the two Tasks here.
+                                updated_tasks_adjacency_matrix[previous_task].append(
+                                    task
+                                )
+
+                # Now that the adjacency matrix has been constructed, we construct a
+                # new TaskGraph with the updated adjacency matrix, and swap it with the
+                # adjacency matrix in the original TaskGraph.
+                if self._log_graphs:
+                    # Dump the original TaskGraph to the log directory.
+                    task_graph.to_dot(
+                        os.path.join(self._log_dir, f"{task_graph_name}_original.dot")
+                    )
+                task_graph.update_edges(updated_tasks_adjacency_matrix)
+                if self._log_graphs:
+                    # Dump the updated TaskGraph to the log directory.
+                    task_graph.to_dot(
+                        os.path.join(self._log_dir, f"{task_graph_name}_updated.dot")
+                    )
+            else:
+                self._logger.error(
+                    "[%s] Failed to find a minimum makespan solution for TaskGraph %s.",
+                    sim_time.time,
+                    task_graph_name,
+                )
+                raise ValueError(
+                    f"Failed to find a minimum makespan solution "
+                    f"for the TaskGraph {task_graph_name}."
+                )
+
+        raise NotImplementedError(
+            "Saving of the transformed TaskGraphs is not yet done."
+        )
 
         # All the TaskGraphs have been transformed, call the TetriSched scheduler and
         # return the Placements.

--- a/schedulers/graphene_scheduler.py
+++ b/schedulers/graphene_scheduler.py
@@ -1,0 +1,10 @@
+try:
+    from .tetrisched_scheduler import TetriSchedScheduler
+except ImportError:
+    raise ImportError(
+        "TetriSchedScheduler not found. " "Please install the TetriSched package."
+    )
+
+
+class GrapheneScheduler(TetriSchedScheduler):
+    pass

--- a/schedulers/tetrisched_scheduler.py
+++ b/schedulers/tetrisched_scheduler.py
@@ -1,5 +1,4 @@
 import os
-import random
 import time
 from collections import defaultdict
 from math import ceil
@@ -1673,9 +1672,6 @@ class TetriSchedScheduler(BaseScheduler):
                 previously placed. Defaults to `False`.
         """
         # Maintain a cache to be used across the construction of the TaskGraph to make
-        # it DAG-aware, if not provided.
-        if task_strls is None:
-            task_strls = {}
         # it DAG-aware, if not provided.
         if task_strls is None:
             task_strls = {}

--- a/schedulers/tetrisched_scheduler.py
+++ b/schedulers/tetrisched_scheduler.py
@@ -708,6 +708,7 @@ class TetriSchedScheduler(BaseScheduler):
                         continue
 
                     # Construct the STRL.
+                    scale_factor = self._previously_placed_reward_scale_factor
                     task_graph_strl = self.construct_task_graph_strl(
                         current_time=sim_time,
                         task_graph=task_graph,
@@ -718,6 +719,8 @@ class TetriSchedScheduler(BaseScheduler):
                         task_strls=task_strls,
                         previously_placed=task_graph_name
                         in previously_placed_task_graphs,
+                        use_indicator_utility=self._use_task_graph_indicator_utility,
+                        scale_reward_previously_placed=scale_factor,
                     )
                     if task_graph_strl is not None:
                         objective_strl.addChild(task_graph_strl)
@@ -1657,6 +1660,8 @@ class TetriSchedScheduler(BaseScheduler):
         tasks_to_be_scheduled: Optional[List[Task]] = None,
         task_strls: Optional[Mapping[str, tetrisched.strl.Expression]] = None,
         previously_placed: Optional[bool] = False,
+        use_indicator_utility: Optional[bool] = False,
+        scale_reward_previously_placed: float = 1.0,
     ) -> tetrisched.strl.Expression:
         """Constructs the STRL expression subtree for a given TaskGraph.
 
@@ -1670,6 +1675,12 @@ class TetriSchedScheduler(BaseScheduler):
                 considered. Defaults to `None`.
             previously_placed (`Optional[bool]`): Whether the TaskGraph has been
                 previously placed. Defaults to `False`.
+            use_indicator_utility (`Optional[bool]`): Whether to use the indicator of
+                the placement of the TaskGraph as the utility. If False, the utility
+                of the individual Task placements is utilized instead.
+            scale_reward_previously_placed (`float`): The factor by which to scale the
+                reward of the TaskGraph if it has been previously placed. Defaults to
+                1.0.
         """
         # Maintain a cache to be used across the construction of the TaskGraph to make
         # it DAG-aware, if not provided.
@@ -1729,21 +1740,21 @@ class TetriSchedScheduler(BaseScheduler):
         # utilities to be scaled, or if we are using the indicator from the topmost
         # TaskGraph expression to scale the utility.
         should_scale = (
-            self._previously_placed_reward_scale_factor > 1.0 and previously_placed
-        ) or self._use_task_graph_indicator_utility
+            scale_reward_previously_placed > 1.0 and previously_placed
+        ) or use_indicator_utility
 
         if should_scale:
             self._logger.debug(
                 "[%s] Scaling the %s of %s by %s.",
                 current_time.to(EventTime.Unit.US).time,
-                "indicator" if self._use_task_graph_indicator_utility else "utility",
+                "indicator" if use_indicator_utility else "utility",
                 task_graph.name,
-                self._previously_placed_reward_scale_factor,
+                scale_reward_previously_placed,
             )
             scale_expression = tetrisched.strl.ScaleExpression(
                 f"{task_graph.name}_scale",
-                self._previously_placed_reward_scale_factor if previously_placed else 1,
-                self._use_task_graph_indicator_utility,
+                scale_reward_previously_placed if previously_placed else 1,
+                use_indicator_utility,
             )
             scale_expression.addChild(task_graph_strl)
             return scale_expression

--- a/simulator.py
+++ b/simulator.py
@@ -1981,6 +1981,10 @@ class Simulator(object):
             self._workload,
             self._worker_pools,
         )
+        if placements is None:
+            raise ValueError(
+                f"Received no Placements object from the Scheduler at {event.time}.",
+            )
 
         # Calculate the time at which the placements need to be applied.
         placement_time = event.time + placements.runtime

--- a/simulator.py
+++ b/simulator.py
@@ -1504,6 +1504,14 @@ class Simulator(object):
             self._csv_logger.info("%s,UPDATE_WORKLOAD,0,0", self._simulator_time.time)
         else:
             self._workload = updated_workload
+            # Notify the Scheduler of the updated Workload.
+            self._scheduler.notify_workload_updated(
+                sim_time=self._simulator_time,
+                workload=self._workload,
+                worker_pools=self._worker_pools,
+            )
+
+            # Release the Tasks that have become available.
             releasable_tasks = self._workload.get_releasable_tasks()
             self._logger.info(
                 "[%s] The WorkloadLoader %s has %s TaskGraphs that released %s tasks.",

--- a/workload/tasks.py
+++ b/workload/tasks.py
@@ -1589,13 +1589,15 @@ class TaskGraph(Graph[Task]):
         # Find the maximum remaining time across all the sink nodes.
         return max([remaining_time[sink] for sink in self.get_sink_tasks()])
 
-    def get_task(self, name: str) -> Optional[Task]:
+    def get_task(self, name: str, unique: bool = False) -> Optional[Task]:
         """Retrieve the Task with the given name from the TaskGraph.
 
         Returns `None` if no such Task exists in the TaskGraph.
 
         Args:
             name (`str`): The name of the Task to retrieve.
+            unique (`bool`): If `True`, then the Task will be matched by its unique
+                name instead of the name.
 
         Returns:
             The `Task` with the given name, if it exists in the TaskGraph.
@@ -1605,11 +1607,23 @@ class TaskGraph(Graph[Task]):
         """
         matched_task = None
         for task in self.get_nodes():
-            if task.name == name:
+            if task.name == name or (unique and task.unique_name == name):
                 if matched_task:
                     raise ValueError(f"Multiple tasks with the name {name} found.")
                 matched_task = task
         return matched_task
+
+    def update_edges(self, tasks: Mapping[Task, Sequence[Task]]) -> None:
+        """Updates the edges inside the TaskGraph according to the new set of tasks.
+        
+        This is used to transform the TaskGraph without changing the references that
+        may be held by other objects to this TaskGraph.
+
+        Args:
+            tasks (`Mapping[Task, Sequence[Task]]`): A mapping of tasks to their
+                children tasks.
+        """
+        super(TaskGraph, self).__init__(tasks)
 
     @property
     def deadline(self) -> EventTime:

--- a/workload/tasks.py
+++ b/workload/tasks.py
@@ -1615,7 +1615,7 @@ class TaskGraph(Graph[Task]):
 
     def update_edges(self, tasks: Mapping[Task, Sequence[Task]]) -> None:
         """Updates the edges inside the TaskGraph according to the new set of tasks.
-        
+
         This is used to transform the TaskGraph without changing the references that
         may be held by other objects to this TaskGraph.
 


### PR DESCRIPTION
This PR aims to replicate the scheduling algorithm proposed by [GRAPHENE: Packing and Dependency-Aware Scheduling for Data-Parallel Clusters](https://www.usenix.org/conference/osdi16/technical-sessions/presentation/grandl_graphene) using two steps:

1. Upon arrival of a TaskGraph, a min makespan schedule for that graph is computed assuming an empty resource-time space. This corresponds to the Offline phase proposed in the Graphene paper.
2. The structure of the TaskGraph is then changed to conform to the min makespan schedule, and tasks are then released by the scheduler as their parents finish their execution. We use an ILP-based packing formulation to then pack tasks from various such TaskGraphs together. This corresponds to the Online phase proposed in the Graphene paper.

### Testing

The offline phase of the Graphene scheduler was tested by implementing the example from Figure 2 of the Graphene paper. The original and the updated TaskGraphs are shown below:

![Screenshot_22-2-2024_132425_](https://github.com/erdos-project/erdos-scheduling-simulator/assets/4013287/0beb93ae-04d9-4345-8d8d-ef2ab06dd65c)
![Screenshot_22-2-2024_132445_](https://github.com/erdos-project/erdos-scheduling-simulator/assets/4013287/a08210f9-8775-422f-9c6b-bff198542ddc)
