### PR TITLE
rename optimization_passes flag to opt_passes

### DIFF
--- a/main.py
+++ b/main.py
@@ -473,7 +473,7 @@ flags.DEFINE_float(
     "placing the TaskGraph, and drop the TaskGraph if it cannot be placed after.",
 )
 flags.DEFINE_multi_enum(
-    "optimization_passes",
+    "opt_passes",
     [],
     [
         "CRITICAL_PATH_PASS",


### PR DESCRIPTION
07d99ba refactored `opt_passes` to `optimization_passes` but did not correspondingly update the use of `flags.opt_passes` in `schedulers/tetrisched_scheduler.py`, which leads to a runtime error.

This patch fixes the runtime error by renaming `optimization_passes` to `opt_passes`. I did it this way because I didn't see `flags.optimization_passes` being referenced anywhere, so it was the simpler fix.