### PR TITLE
setting start_time for tasks after placement

### DIFF
--- a/simulator.py
+++ b/simulator.py
@@ -758,6 +758,9 @@ class Simulator(object):
                     placement.placement_time,
                 )
                 placement.task.schedule(event_time, placement)
+                
+                # set task's start_time to the placement_time
+                placement.task._start_time = placement.placement_time
 
                 simulator_event = Event(
                     event_type=EventType.TASK_PLACEMENT,
@@ -790,6 +793,10 @@ class Simulator(object):
                         placement.placement_time,
                     )
                     placement.task.schedule(event_time, placement)
+                    
+                    # reset task's start_time to the new placement_time
+                    placement.task._start_time = placement.placement_time
+                    
                     simulator_event = Event(
                         event_type=EventType.TASK_PLACEMENT,
                         time=placement.placement_time,


### PR DESCRIPTION
`start_time` attribute for tasks was not being set, so it remained -1 in the logs. This is confusing. Hence pushing a small fix to set the `start_time` of the task denoting when the task is supposed to start running.